### PR TITLE
Add UI tweaks and mobile responsiveness

### DIFF
--- a/src/app/components/Input.tsx
+++ b/src/app/components/Input.tsx
@@ -20,7 +20,7 @@ function Input({
   id = ''
 }: IInput) {
   return (
-    <div className="flex h-16 flex-row items-center justify-between gap-x-8">
+    <div className="flex h-fit sm:h-16 flex-col sm:flex-row items-center justify-between gap-x-8 gap-y-8">
       <div className="bg-background-900 flex h-full w-full flex-row items-center justify-between p-4">
         <p className="text-text-50 text-xl">{label}</p>
         <TooltipProvider>
@@ -40,7 +40,7 @@ function Input({
         id={id}
         disabled={disabled}
         {...register(id, { ...register_options })}
-        className="bg-background-50 text-text-950 border-background-200 focus:ring-accent-400 h-full w-64 border p-2 text-xl transition-all duration-300 focus:ring-2 focus:outline-none"
+        className={`bg-background-50 text-text-950 border-background-200 focus:ring-accent-400 h-16 sm:h-full w-full sm:w-64 border p-2 text-xl transition-all duration-300 focus:ring-2 focus:outline-none ${error ? 'border-red-500' : ''} ${className}`}
         placeholder={placeholder}
         defaultValue={defaultValue}
       />

--- a/src/app/components/button.tsx
+++ b/src/app/components/button.tsx
@@ -23,7 +23,7 @@ function Button({
       type={type}
       onClick={onClick}
       disabled={disabled || loading}
-      className={`text-text-50 bg-accent-500 hover:bg-accent-600 rounded-sm px-10 py-2 text-2xl transition-colors duration-300 disabled:cursor-not-allowed disabled:opacity-50 ${className}`}
+      className={`text-text-50 bg-accent-500 hover:bg-accent-600 w-full sm:min-w-64 sm:w-fit items-center justify-center rounded-sm px-10 py-4 text-2xl transition-colors duration-300 disabled:cursor-not-allowed disabled:opacity-50 ${className}`}
     >
       {loading ? (
         <Loader className="text-text-50 animate-spin" size={20} />

--- a/src/app/components/navbar.tsx
+++ b/src/app/components/navbar.tsx
@@ -1,9 +1,10 @@
-import { Link } from "react-router-dom"
-import { useContext } from "react";
-import { DrawerContext, DrawerContextProvider } from "@/app/contexts/Drawer-context";
-import { InformationDrawer } from "@/app/pages/informationDrawer";
+import { DrawerContext } from "@/app/contexts/Drawer-context";
 import { HowToUseDrawer } from "@/app/pages/howToUseDrawer";
+import { InformationDrawer } from "@/app/pages/informationDrawer";
 import { TableDrawer } from "@/app/pages/tableDrawer";
+import { Menu } from "lucide-react";
+import { useContext } from "react";
+import { Link } from "react-router-dom";
 
 function Navbar() {
   /* TODO: 
@@ -14,9 +15,9 @@ function Navbar() {
   const drawerContext = useContext(DrawerContext)
 
   return (
-    <nav className="bg-background-900 flex h-20 w-full flex-row items-center gap-x-8 px-8 sticky top-0 z-50">
+    <nav className="bg-background-900 flex h-20 w-full flex-row items-center justify-between sm:justify-start gap-x-8 px-8 sticky top-0 z-50">
       <img src="icon.svg" alt="Logo" className="h-10" />
-      <ul className="flex flex-row items-center justify-start gap-x-8 text-base">
+      <ul className="hidden sm:flex flex-row items-center justify-start gap-x-8 text-base">
         <li className="text-text-50 hover:text-accent-400 cursor-pointer transition-colors duration-300">
           <div onClick={() => {
             drawerContext?.setIsOpen(true);
@@ -39,6 +40,7 @@ function Navbar() {
           <Link to={``}>Saiba mais</Link>
         </li>
       </ul>
+      <Menu className="text-white cursor-pointer sm:hidden"/>
     </nav>
   )
 }

--- a/src/app/pages/calculations/AverageIlluminance.tsx
+++ b/src/app/pages/calculations/AverageIlluminance.tsx
@@ -1,4 +1,4 @@
-import Button from '@/app/components/Button'
+import Button from '@/app/components/button'
 import Input from '@/app/components/Input'
 import { IAverageIlluminanceSchema } from '@/app/pages/services/atributes-validation'
 import { zodResolver } from '@hookform/resolvers/zod'

--- a/src/app/pages/calculations/AverageIlluminance.tsx
+++ b/src/app/pages/calculations/AverageIlluminance.tsx
@@ -8,7 +8,7 @@ import type z from 'zod'
 
 type IAverageIlluminance = z.infer<typeof IAverageIlluminanceSchema>;
 
-export function AverageIlluminance({edlValue}: {edlValue: number | null}) {
+export function AverageIlluminance() {
   const [isLoading, setIsLoading] = useState(false)
   const [result, setResult] = useState<number | null>(null)
 
@@ -131,7 +131,6 @@ export function AverageIlluminance({edlValue}: {edlValue: number | null}) {
             disabled={isLoading}
             loading={isLoading}
             className="bg-accent-400 hover:bg-accent-500 text-text-50 cursor-pointer"
-            onClick={() => handleSubmitData()}
           >
             Calcular
           </Button>

--- a/src/app/pages/calculations/NumberOfDucts.tsx
+++ b/src/app/pages/calculations/NumberOfDucts.tsx
@@ -1,4 +1,4 @@
-import Button from '@/app/components/Button'
+import Button from '@/app/components/button'
 import Input from '@/app/components/Input'
 import { INumberOfDuctsSchema } from '@/app/pages/services/atributes-validation'
 import { zodResolver } from '@hookform/resolvers/zod'
@@ -152,8 +152,8 @@ export function NumberOfDucts() {
       />
       <div>
         <p className="text-lg">Resultado:</p>
-        <div className="flex flex-row items-center justify-between gap-x-4">
-          <div className="border-accent-400 w-64 max-w-64 border-2 p-4">
+        <div className="flex flex-col sm:flex-row items-start gap-y-8 sm:items-center justify-between gap-x-4">
+          <div className="border-accent-500 w-full sm:w-64 sm:max-w-64 border-2 p-4">
             <p className="text-text-950 text-lg font-semibold">
               {result !== null ? result : '0.00'}
             </p>

--- a/src/app/pages/calculations/NumberOfDucts.tsx
+++ b/src/app/pages/calculations/NumberOfDucts.tsx
@@ -2,33 +2,70 @@ import Button from '@/app/components/Button'
 import Input from '@/app/components/Input'
 import { INumberOfDuctsSchema } from '@/app/pages/services/atributes-validation'
 import { zodResolver } from '@hookform/resolvers/zod'
-import { useState } from 'react'
+import axios from 'axios'
+import { useEffect, useState } from 'react'
 import { useForm, type SubmitHandler } from 'react-hook-form'
 import type z from 'zod'
 
 type INumberOfDucts = z.infer<typeof INumberOfDuctsSchema>;
 
-export function NumberOfDucts({edlValue}: {edlValue: number | null}) {
+export function NumberOfDucts() {
   const [isLoading, setIsLoading] = useState(false)
   const [result, setResult] = useState<number | null>(null)
 
   const {
     register,
     handleSubmit,
+    watch,
+    setValue,
+    getValues,
     formState: { errors }
   } = useForm<INumberOfDucts>({
     resolver: zodResolver(INumberOfDuctsSchema)
   })
-  const onSubmit: SubmitHandler<INumberOfDucts> = (data) => console.log(data)
+  const onSubmit: SubmitHandler<INumberOfDucts> = (data) => handleSubmitData(data)
 
-  function handleSubmitData() {
+  async function handleSubmitData(data: INumberOfDucts) {
     setIsLoading(true)
-    // Mock a network request
-    setTimeout(() => {
-      setIsLoading(false)
-      setResult(10)
-    }, 2000)
+
+    const edlValue = localStorage.getItem('edlValue');
+    const bSection = localStorage.getItem('b_section');
+    
+    if (!edlValue || !bSection) {
+      console.error('EDL value or B section not found in localStorage');
+      setIsLoading(false);
+      return;
+    }
+
+    const params = new URLSearchParams({
+      edl_prcnt: edlValue!.toString(),
+      b_section: Number(bSection).toString(),
+      e_lux: data.e_lux.toString(),
+      e_external: data.e_external.toString(),
+      a_area: data.a.toString(),
+      fd_value: data.fd.toString(),
+    }).toString();
+
+    try {
+      const response = await axios.post(`https://9gmtpev0s7.execute-api.sa-east-1.amazonaws.com/prod/luz-mss/calculate-n-value?${params}`);
+      setResult(response.data.calculated_n_value);
+    } catch (error) {
+      console.error(error);
+    } finally {
+      setIsLoading(false);
+    }
   }
+
+  useEffect(() => {
+    const edlValue = Number(localStorage.getItem('edlValue'));
+    const bValue = Number(localStorage.getItem('b_section'));
+    const e_external = getValues('e_external');
+
+    const edllux = (edlValue * e_external) / 100;
+
+    setValue('phi_duct', (edllux) * (Number(Math.pow(bValue, 2).toFixed(2))));
+
+  }, [watch('e_external'), localStorage.getItem('edlValue'), localStorage.getItem('b_section')]);
 
   return (
     <form onSubmit={handleSubmit(onSubmit)} className="flex flex-col gap-4">
@@ -41,9 +78,9 @@ export function NumberOfDucts({edlValue}: {edlValue: number | null}) {
           required: 'Campo obrigatório',
           valueAsNumber: true
         }}
-        type="number"
+        type="float"
         placeholder="E (Lux)"
-        id="inputE"
+        id="e_lux"
       />
       <Input
         label="E externo"
@@ -54,9 +91,9 @@ export function NumberOfDucts({edlValue}: {edlValue: number | null}) {
           required: 'Campo obrigatório',
           valueAsNumber: true
         }}
-        type="number"
+        type="float"
         placeholder="E externo (Lux)"
-        id="inputEExternal"
+        id="e_external"
       />
       <Input
         label="φ (Fator de reflexão do duto)"
@@ -67,10 +104,10 @@ export function NumberOfDucts({edlValue}: {edlValue: number | null}) {
           required: 'Campo obrigatório',
           valueAsNumber: true
         }}
-        type="number"
+        type="float"
         // placeholder="φ"
         disabled={true}
-        id="inputPhiDuct"
+        id="phi_duct"
       />
       <Input
         label="A (Área do duto)"
@@ -81,9 +118,9 @@ export function NumberOfDucts({edlValue}: {edlValue: number | null}) {
           required: 'Campo obrigatório',
           valueAsNumber: true
         }}
-        type="number"
+        type="float"
         placeholder="A (m²)"
-        id="inputArea"
+        id="a"
       />
       <Input
         label="Fd (Fator de distribuição)"
@@ -94,9 +131,9 @@ export function NumberOfDucts({edlValue}: {edlValue: number | null}) {
           required: 'Campo obrigatório',
           valueAsNumber: true
         }}
-        type="number"
+        type="float"
         placeholder="Fd"
-        id="inputFd"
+        id="fd"
       />
       <Input
         label="Cd (Coeficiente de dutos)"
@@ -107,11 +144,11 @@ export function NumberOfDucts({edlValue}: {edlValue: number | null}) {
           required: 'Campo obrigatório',
           valueAsNumber: true
         }}
-        type="number"
+        type="float"
         defaultValue={3}
         // placeholder="Cd"
         disabled= {true}
-        id="inputCd"
+        id="cd"
       />
       <div>
         <p className="text-lg">Resultado:</p>
@@ -126,7 +163,6 @@ export function NumberOfDucts({edlValue}: {edlValue: number | null}) {
             disabled={isLoading}
             loading={isLoading}
             className="bg-accent-400 hover:bg-accent-500 text-text-50 cursor-pointer"
-            onClick={() => handleSubmitData()}
           >
             Calcular
           </Button>

--- a/src/app/pages/home.tsx
+++ b/src/app/pages/home.tsx
@@ -129,7 +129,7 @@ export function Home() {
                 id="section"
               />
               <Input
-                label="h (Altura)"
+                label="c (Comprimento)"
                 tooltip="Comprimento do duto (m)"
                 register={register}
                 error={errors.height?.message}

--- a/src/app/pages/home.tsx
+++ b/src/app/pages/home.tsx
@@ -1,6 +1,6 @@
-import Button from '@/app/components/Button'
+import Button from '@/app/components/button'
 import Input from '@/app/components/Input'
-import Navbar from '@/app/components/Navbar'
+import Navbar from '@/app/components/navbar'
 import { DrawerContext } from '@/app/contexts/Drawer-context'
 import { AverageIlluminance } from '@/app/pages/calculations/AverageIlluminance'
 import { NumberOfDucts } from '@/app/pages/calculations/NumberOfDucts'
@@ -156,8 +156,8 @@ export function Home() {
               />
               <div>
                 <p className="text-lg">Resultado:</p>
-                <div className="flex flex-row items-center justify-between gap-x-4">
-                  <div className="border-accent-400 w-64 max-w-64 border-2 p-4">
+                <div className="flex flex-col sm:flex-row items-start gap-y-8 sm:items-center justify-between gap-x-4">
+                  <div className="border-accent-500 w-full sm:w-64 sm:max-w-64 border-2 p-4">
                     <p className="text-text-950 text-lg font-semibold">
                       EDL = {edlValue !== null ? edlValue : '0.00'}
                     </p>
@@ -187,13 +187,13 @@ export function Home() {
                   <p className="text-text-950 text-lg">
                     2. Selecione o que deseja calcular
                   </p>
-                  <div className="flex w-full max-w-[642px] flex-row items-center justify-between">
+                  <div className="flex w-full sm:max-w-[642px] flex-row items-center justify-between gap-x-2">
                     <button
                       onClick={() => {
                         setSelectedCalculation('numberOfDucts')
                       }}
                       className={cn(
-                        'text-text-50 hover:bg-background-700 bg-background-800 cursor-pointer rounded-sm p-4 px-6 min-w-48 transition-colors duration-300',
+                        'text-text-50 hover:bg-background-700 bg-background-800 cursor-pointer rounded-sm p-4 px-6 w-full sm:min-w-48 transition-colors duration-300',
                         selectedCalculation === 'numberOfDucts' &&
                           'bg-accent-500 text-text-50'
                       )}
@@ -205,7 +205,7 @@ export function Home() {
                         setSelectedCalculation('averageIlluminance')
                       }}
                       className={cn(
-                        'text-text-50 hover:bg-background-700 bg-background-800 cursor-pointer rounded-sm p-4 px-6 min-w-48 transition-colors duration-300',
+                        'text-text-50 hover:bg-background-700 bg-background-800 cursor-pointer rounded-sm p-4 px-6 w-full sm:min-w-48 transition-colors duration-300',
                         selectedCalculation === 'averageIlluminance' &&
                           'bg-accent-500 text-text-50'
                       )}

--- a/src/app/pages/home.tsx
+++ b/src/app/pages/home.tsx
@@ -35,11 +35,11 @@ export function Home() {
   > = {
     numberOfDucts: {
       title: 'Número de Dutos',
-      component: <NumberOfDucts edlValue={edlValue} />
+      component: <NumberOfDucts />
     },
     averageIlluminance: {
       title: 'Iluminância Média',
-      component: <AverageIlluminance edlValue={edlValue} />
+      component: <AverageIlluminance />
     }
   }
 
@@ -66,6 +66,11 @@ export function Home() {
     try {
       const response = await axios.post(`https://9gmtpev0s7.execute-api.sa-east-1.amazonaws.com/prod/luz-mss/calculate-edl-value?${params}`);
       setEdlValue(response.data.calculated_edl_value);
+
+      // Save edlValue to localStorage
+      localStorage.setItem('edlValue', response.data.calculated_edl_value);
+      // Save b_section to localStorage
+      localStorage.setItem('b_section', String(data.section));
     } catch (error) {
       console.error(error);
     } finally {

--- a/src/app/pages/informationDrawer.tsx
+++ b/src/app/pages/informationDrawer.tsx
@@ -1,7 +1,7 @@
 import { Drawer, DrawerContent, DrawerTopbar } from "@/app/components/drawer";
-import { AnimatePresence } from "framer-motion";
 import { EDLFormula, EDLFormula2, NFormula, PhiFormula, RCRFormula } from "@/app/components/formula";
 import { DrawerContext } from "@/app/contexts/Drawer-context";
+import { AnimatePresence } from "framer-motion";
 import { useContext } from "react";
 
 function Information() {
@@ -16,7 +16,7 @@ function Information() {
                     CD é o coeficiente de distribuição *; <br />
                     i - número de reflexões do plano iluminado no interior do duto; <br />
                     b - largura da seção do duto (m); <br />
-                    h - comprimento do duto (m); <br />
+                    c - comprimento do duto (m); <br />
                     ρ - refletância interna ao duto; <br />
                     n - número de reflexões do plano emissor, consideradas no somatório; <br />
                     RCR - coeficiente do recinto; <br />

--- a/src/app/pages/services/atributes-validation.tsx
+++ b/src/app/pages/services/atributes-validation.tsx
@@ -20,12 +20,12 @@ const IAverageIlluminanceSchema= z.object({
 // type IAverageIlluminanceValidation = z.infer<typeof IAverageIlluminanceSchema>;
 
 const INumberOfDuctsSchema= z.object({
-  e_lux: z.number().min(1, {message: "O E lux tem que ser maior que 0"}),
-  e_external: z.number().min(1, {message: "O E Externo tem que ser maior que 0"}),
-  phi_duct: z.number().min(1, {message: "O φ tem que ser maior que 0"}),
-  a: z.number().min(1, {message: "O A tem que ser maior que 0"}),
-  fd: z.number().min(1, {message: "O Fd tem que ser maior que 0"}),
-  cd: z.number().min(1, {message: "O Cd tem que ser maior que 0"})
+  e_lux: z.number().min(0, {message: "O E lux tem que ser maior que 0"}),
+  e_external: z.number().min(0, {message: "O E Externo tem que ser maior que 0"}),
+  phi_duct: z.number().min(0, {message: "O φ tem que ser maior que 0"}),
+  a: z.number().min(0, {message: "O A tem que ser maior que 0"}),
+  fd: z.number().min(0, {message: "O Fd tem que ser maior que 0"}),
+  cd: z.number().min(0, {message: "O Cd tem que ser maior que 0"})
 });
 
 // type INumberOfDuctsValidation = z.infer<typeof INumberOfDuctsSchema>;


### PR DESCRIPTION
This pull request introduces several improvements and refactors to the calculation pages, form components, and UI responsiveness. The changes streamline data flow between calculation steps, enhance the user experience on different screen sizes, and improve code consistency and maintainability.

**Calculation Logic and Data Flow Enhancements:**

* The `NumberOfDucts` and `AverageIlluminance` components no longer receive `edlValue` as a prop; instead, they retrieve necessary values from `localStorage`, aligning data flow and reducing prop drilling. EDL and section values are now saved to `localStorage` after calculation in the `Home` component. [[1]](diffhunk://#diff-d33edb1826ec4e6c14213a37e05d5505c57b8989634affe4885b526affcb8c77L1-R68) [[2]](diffhunk://#diff-d33edb1826ec4e6c14213a37e05d5505c57b8989634affe4885b526affcb8c77L1-R68)4R17, [[3]](diffhunk://#diff-68b58fb184bbc28201381e2c72fb0688b837797a3afe7e42e2b8ab979e13cc54L38-R42) [[4]](diffhunk://#diff-68b58fb184bbc28201381e2c72fb0688b837797a3afe7e42e2b8ab979e13cc54R69-R73)
* The `NumberOfDucts` calculation now performs an API call with dynamic parameters from both user input and `localStorage`, and automatically computes and sets the `phi_duct` field using a `useEffect` hook. [[1]](diffhunk://#diff-d33edb1826ec4e6c14213a37e05d5505c57b8989634affe4885b526affcb8c77L1-R68)4R17, [[2]](diffhunk://#diff-d33edb1826ec4e6c14213a37e05d5505c57b8989634affe4885b526affcb8c77L44-R83)
* Validation schemas for `NumberOfDucts` input fields now accept zero as a valid minimum value, improving flexibility for edge cases.

**UI and Responsiveness Improvements:**

* Input and button components have been updated for better responsiveness: layouts now adapt between column and row on small screens, and widths are set to be more mobile-friendly. [[1]](diffhunk://#diff-0139502b1f148b6820b1f7fbfad5dad4ada9dcdf9783203164864c55d062f5f2L23-R23) [[2]](diffhunk://#diff-0139502b1f148b6820b1f7fbfad5dad4ada9dcdf9783203164864c55d062f5f2L43-R43) [[3]](diffhunk://#diff-e49e7bfed7da64c47ba0dcf10c18edce1149d8600d8257fc69795dfb42dc6f71L26-R26) [[4]](diffhunk://#diff-68b58fb184bbc28201381e2c72fb0688b837797a3afe7e42e2b8ab979e13cc54L185-R196) [[5]](diffhunk://#diff-68b58fb184bbc28201381e2c72fb0688b837797a3afe7e42e2b8ab979e13cc54L203-R208)
* Calculation result containers and selection buttons are now styled to stack vertically on small screens and use accent colors for improved visual feedback. [[1]](diffhunk://#diff-d33edb1826ec4e6c14213a37e05d5505c57b8989634affe4885b526affcb8c77L110-R156) [[2]](diffhunk://#diff-68b58fb184bbc28201381e2c72fb0688b837797a3afe7e42e2b8ab979e13cc54L154-R160)

**Consistency and Naming:**

* File and component imports have been standardized to use consistent casing (e.g., `button` instead of `Button`, `navbar` instead of `Navbar`). [[1]](diffhunk://#diff-9780cd2a039f41830528ef77846a3a3dcccab77211ea9a44d78b0164ff7e3ebdL1-R1) [[2]](diffhunk://#diff-d33edb1826ec4e6c14213a37e05d5505c57b8989634affe4885b526affcb8c77L1-R68) [[3]](diffhunk://#diff-68b58fb184bbc28201381e2c72fb0688b837797a3afe7e42e2b8ab979e13cc54L1-R3)
* The label and documentation for the duct length input have been updated from "h (Altura)" to "c (Comprimento)" for clarity and consistency across the UI and information drawer. [[1]](diffhunk://#diff-68b58fb184bbc28201381e2c72fb0688b837797a3afe7e42e2b8ab979e13cc54L127-R132) [[2]](diffhunk://#diff-7aab11d544a835e8d42fd5553203636a681e8a7bbed6f0f2213cb5b8f3a9cc7cL19-R19)

**Navbar and Drawer Refactor:**

* The `Navbar` component has been refactored for better import order, and now includes a mobile menu icon that is only visible on small screens. Navigation links are hidden on mobile for a cleaner UI. [[1]](diffhunk://#diff-58aab705efecdb0e3ff126b7169a99d00b1f9226ef75ad9b0a3afc37669f6657L1-R7) [[2]](diffhunk://#diff-58aab705efecdb0e3ff126b7169a99d00b1f9226ef75ad9b0a3afc37669f6657L17-R20) [[3]](diffhunk://#diff-58aab705efecdb0e3ff126b7169a99d00b1f9226ef75ad9b0a3afc37669f6657R43)

**Other Minor Improvements:**

* Input types for calculation fields have been changed from `number` to `float` for more accurate data entry. [[1]](diffhunk://#diff-d33edb1826ec4e6c14213a37e05d5505c57b8989634affe4885b526affcb8c77L44-R83) [[2]](diffhunk://#diff-d33edb1826ec4e6c14213a37e05d5505c57b8989634affe4885b526affcb8c77L57-R96) [[3]](diffhunk://#diff-d33edb1826ec4e6c14213a37e05d5505c57b8989634affe4885b526affcb8c77L70-R110) [[4]](diffhunk://#diff-d33edb1826ec4e6c14213a37e05d5505c57b8989634affe4885b526affcb8c77L84-R123) [[5]](diffhunk://#diff-d33edb1826ec4e6c14213a37e05d5505c57b8989634affe4885b526affcb8c77L97-R136) [[6]](diffhunk://#diff-d33edb1826ec4e6c14213a37e05d5505c57b8989634affe4885b526affcb8c77L110-R156)
* Unused props and click handlers have been removed from calculation buttons for cleaner code. [[1]](diffhunk://#diff-9780cd2a039f41830528ef77846a3a3dcccab77211ea9a44d78b0164ff7e3ebdL134) [[2]](diffhunk://#diff-d33edb1826ec4e6c14213a37e05d5505c57b8989634affe4885b526affcb8c77L129)

These changes collectively improve the maintainability, usability, and responsiveness of the application.

**References:**  
[[1]](diffhunk://#diff-d33edb1826ec4e6c14213a37e05d5505c57b8989634affe4885b526affcb8c77L1-R68) [[2]](diffhunk://#diff-d33edb1826ec4e6c14213a37e05d5505c57b8989634affe4885b526affcb8c77L1-R68)4R17, [[3]](diffhunk://#diff-d33edb1826ec4e6c14213a37e05d5505c57b8989634affe4885b526affcb8c77L44-R83) [[4]](diffhunk://#diff-20ce064cbf2d34f79308d6c92543eb62064e29af6243e8785e7dc85d6e4e14e2L23-R28) [[5]](diffhunk://#diff-0139502b1f148b6820b1f7fbfad5dad4ada9dcdf9783203164864c55d062f5f2L23-R23) [[6]](diffhunk://#diff-0139502b1f148b6820b1f7fbfad5dad4ada9dcdf9783203164864c55d062f5f2L43-R43) [[7]](diffhunk://#diff-e49e7bfed7da64c47ba0dcf10c18edce1149d8600d8257fc69795dfb42dc6f71L26-R26) [[8]](diffhunk://#diff-68b58fb184bbc28201381e2c72fb0688b837797a3afe7e42e2b8ab979e13cc54L185-R196) [[9]](diffhunk://#diff-68b58fb184bbc28201381e2c72fb0688b837797a3afe7e42e2b8ab979e13cc54L203-R208) [[10]](diffhunk://#diff-d33edb1826ec4e6c14213a37e05d5505c57b8989634affe4885b526affcb8c77L110-R156) [[11]](diffhunk://#diff-68b58fb184bbc28201381e2c72fb0688b837797a3afe7e42e2b8ab979e13cc54L154-R160) [[12]](diffhunk://#diff-9780cd2a039f41830528ef77846a3a3dcccab77211ea9a44d78b0164ff7e3ebdL1-R1) [[13]](diffhunk://#diff-68b58fb184bbc28201381e2c72fb0688b837797a3afe7e42e2b8ab979e13cc54L1-R3) [[14]](diffhunk://#diff-68b58fb184bbc28201381e2c72fb0688b837797a3afe7e42e2b8ab979e13cc54L38-R42) [[15]](diffhunk://#diff-68b58fb184bbc28201381e2c72fb0688b837797a3afe7e42e2b8ab979e13cc54R69-R73) [[16]](diffhunk://#diff-68b58fb184bbc28201381e2c72fb0688b837797a3afe7e42e2b8ab979e13cc54L127-R132) [[17]](diffhunk://#diff-7aab11d544a835e8d42fd5553203636a681e8a7bbed6f0f2213cb5b8f3a9cc7cL19-R19) [[18]](diffhunk://#diff-58aab705efecdb0e3ff126b7169a99d00b1f9226ef75ad9b0a3afc37669f6657L1-R7) [[19]](diffhunk://#diff-58aab705efecdb0e3ff126b7169a99d00b1f9226ef75ad9b0a3afc37669f6657L17-R20) [[20]](diffhunk://#diff-58aab705efecdb0e3ff126b7169a99d00b1f9226ef75ad9b0a3afc37669f6657R43) [[21]](diffhunk://#diff-9780cd2a039f41830528ef77846a3a3dcccab77211ea9a44d78b0164ff7e3ebdL134) [[22]](diffhunk://#diff-d33edb1826ec4e6c14213a37e05d5505c57b8989634affe4885b526affcb8c77L129)